### PR TITLE
Allowing a symbol to be used as the bundle name

### DIFF
--- a/lib/asset_hat.rb
+++ b/lib/asset_hat.rb
@@ -173,7 +173,7 @@ module AssetHat
       return
     end
 
-    self.config[type.to_s]['bundles'][bundle] rescue nil
+    self.config[type.to_s]['bundles'][bundle.to_s] rescue nil
   end
 
   # Returns the full paths of files in the given bundle:

--- a/test/asset_hat_helper_test.rb
+++ b/test/asset_hat_helper_test.rb
@@ -403,6 +403,15 @@ class AssetHatHelperTest < ActionView::TestCase
           assert_equal expected, output
         end
 
+        should 'include a bundle as a separate using a symbol as input' do
+          bundle = :"js-bundle-1"
+          sources = @config['js']['bundles'][bundle.to_s]
+          expected = sources.
+            map { |src| js_tag("#{src}.js?#{@asset_id}") }.join("\n")
+          output = include_js(:bundle => bundle, :cache => false)
+          assert_equal expected, output
+        end
+
         should 'include multiple bundles as separate files' do
           bundles = [1,2,3].map { |i| "js-bundle-#{i}" }
           expected = bundles.map do |bundle|


### PR DESCRIPTION
Hi,

I thought this was a bug for a while, but after carefully reading through your readme, I realized I was calling a method incorrectly, though in a manner not particularly unexpected.

Instead of calling my JS bundle name like this:

<pre>
include_js(:bundle => 'application')
</pre>

I was doing this:

<pre>
include_js(:bundle => :application)
</pre>

Passing a symbol as the bundle name would make the asset packaging fail silently.

So this little patch allows the use of either a symbol or a string as the name of the bundle in the above syntax.  I've included a test that verifies this.  This patch applies cleanly to both your development and master branch.

I hope you find it useful.

Casey
