### PR TITLE
Fix capistrano deployment task

### DIFF
--- a/lib/asset_hat/capistrano.rb
+++ b/lib/asset_hat/capistrano.rb
@@ -7,7 +7,7 @@ Capistrano::Configuration.instance(:must_exist).load do
       task :minify, :roles => :assets, :except => {:no_release => true} do
         rake = fetch(:rake, "rake")
         env  = fetch(:environment, fetch(:rails_env, "production"))
-        run "cd #{current_path} ; " +
+        run "cd #{release_path} ; " +
             "#{rake} RAILS_ENV=#{env} FORMAT=short asset_hat:minify"
       end
     end


### PR DESCRIPTION
Hello,

just a small one line fix to capistrano deployment task. If you are building assets after deploy:update_code your current_path is still pointing to the old release and you're building old assets in older revisions folder. current_path is symlinked to the new revision in the next deployment task deploy:symlink which follows after update_code. This is also problematic if you're starting to use asset_hat in an existing project since when asset building task executes it just cannot find the rake task (there is no asset_hat gem in older revision).

Commit provides a simple fix by using release_path variable instead of current path.

Cheers,
Saulius
