### PR TITLE
Fixed task definitions to clear up rake 0.9.2 deprecation warnings

### DIFF
--- a/lib/asset_hat/tasks.rb
+++ b/lib/asset_hat/tasks.rb
@@ -4,7 +4,7 @@ require 'asset_hat/tasks/js'
 namespace :asset_hat do
 
   desc 'Minifies all CSS and JS bundles'
-  task :minify, :needs => :environment do
+  task :minify => :environment do
     format = ENV['FORMAT']
     print 'Minifying CSS/JS...'
     puts unless format == 'dot'

--- a/lib/asset_hat/tasks/css.rb
+++ b/lib/asset_hat/tasks/css.rb
@@ -2,7 +2,7 @@ namespace :asset_hat do
   namespace :css do
 
     desc 'Adds commit IDs to asset URLs in CSS for cache busting'
-    task :add_asset_commit_ids, :filename, :needs => :environment do |t, args|
+    task :add_asset_commit_ids, [:filename] => :environment do |t, args|
       if args.filename.blank?
         raise 'Usage: rake asset_hat:css:' +
           'add_asset_commit_ids[filename.css]' and return
@@ -18,7 +18,7 @@ namespace :asset_hat do
     end
 
     desc 'Adds hosts to asset URLs in CSS'
-    task :add_asset_hosts, :filename, :needs => :environment do |t, args|
+    task :add_asset_hosts, [:filename] => :environment do |t, args|
       if args.filename.blank?
         raise 'Usage: rake asset_hat:css:' +
           'add_asset_hosts[filename.css]' and return
@@ -40,7 +40,7 @@ namespace :asset_hat do
     end
 
     desc 'Minifies one CSS file'
-    task :minify_file, :filepath, :needs => :environment do |t, args|
+    task :minify_file, [:filepath] => :environment do |t, args|
       type = 'css'
 
       if args.filepath.blank?
@@ -65,7 +65,7 @@ namespace :asset_hat do
     end
 
     desc 'Minifies one CSS bundle'
-    task :minify_bundle, :bundle, :needs => :environment do |t, args|
+    task :minify_bundle, [:bundle] => :environment do |t, args|
       type = 'css'
 
       if args.bundle.blank?
@@ -155,7 +155,7 @@ namespace :asset_hat do
     end
 
     desc 'Concatenates and minifies all CSS bundles'
-    task :minify, :opts, :needs => :environment do |t, args|
+    task :minify, [:opts] => :environment do |t, args|
       args.with_defaults(:opts => {})
       opts = args.opts.reverse_merge(:show_intro => true, :show_outro => true)
       type = 'css'

--- a/lib/asset_hat/tasks/js.rb
+++ b/lib/asset_hat/tasks/js.rb
@@ -2,7 +2,7 @@ namespace :asset_hat do
   namespace :js do
 
     desc 'Minifies one JS file'
-    task :minify_file, :filepath, :needs => :environment do |t, args|
+    task :minify_file, [:filepath] => :environment do |t, args|
       type = 'js'
 
       if args.filepath.blank?
@@ -31,7 +31,7 @@ namespace :asset_hat do
     end
 
     desc 'Minifies one JS bundle'
-    task :minify_bundle, :bundle, :needs => :environment do |t, args|
+    task :minify_bundle, [:bundle] => :environment do |t, args|
       type = 'js'
 
       if args.bundle.blank?
@@ -104,7 +104,7 @@ namespace :asset_hat do
     end
 
     desc 'Concatenates and minifies all JS bundles'
-    task :minify, :opts, :needs => :environment do |t, args|
+    task :minify, [:opts] => :environment do |t, args|
       args.with_defaults(:opts => {})
       opts = args.opts.reverse_merge(:show_intro => true, :show_outro => true)
       type = 'js'


### PR DESCRIPTION
WARNING: 'task :t, arg, :needs => [deps]' is deprecated.  Please use 'task :t, [args] => [deps]' instead.
    at /Users/jason_pearl/Developer/.rvm/gems/ruby-1.9.2-p180/gems/asset_hat-0.4.1/lib/asset_hat/tasks/css.rb:5:in `block (2 levels) in <top (required)>'
WARNING: 'task :t, arg, :needs => [deps]' is deprecated.  Please use 'task :t, [args] => [deps]' instead.
    at /Users/jason_pearl/Developer/.rvm/gems/ruby-1.9.2-p180/gems/asset_hat-0.4.1/lib/asset_hat/tasks/css.rb:21:in`block (2 levels) in <top (required)>'
WARNING: 'task :t, arg, :needs => [deps]' is deprecated.  Please use 'task :t, [args] => [deps]' instead.
    at /Users/jason_pearl/Developer/.rvm/gems/ruby-1.9.2-p180/gems/asset_hat-0.4.1/lib/asset_hat/tasks/css.rb:43:in `block (2 levels) in <top (required)>'
WARNING: 'task :t, arg, :needs => [deps]' is deprecated.  Please use 'task :t, [args] => [deps]' instead.
    at /Users/jason_pearl/Developer/.rvm/gems/ruby-1.9.2-p180/gems/asset_hat-0.4.1/lib/asset_hat/tasks/css.rb:68:in`block (2 levels) in <top (required)>'
WARNING: 'task :t, arg, :needs => [deps]' is deprecated.  Please use 'task :t, [args] => [deps]' instead.
    at /Users/jason_pearl/Developer/.rvm/gems/ruby-1.9.2-p180/gems/asset_hat-0.4.1/lib/asset_hat/tasks/css.rb:158:in `block (2 levels) in <top (required)>'
WARNING: 'task :t, arg, :needs => [deps]' is deprecated.  Please use 'task :t, [args] => [deps]' instead.
    at /Users/jason_pearl/Developer/.rvm/gems/ruby-1.9.2-p180/gems/asset_hat-0.4.1/lib/asset_hat/tasks/js.rb:5:in`block (2 levels) in <top (required)>'
WARNING: 'task :t, arg, :needs => [deps]' is deprecated.  Please use 'task :t, [args] => [deps]' instead.
    at /Users/jason_pearl/Developer/.rvm/gems/ruby-1.9.2-p180/gems/asset_hat-0.4.1/lib/asset_hat/tasks/js.rb:34:in `block (2 levels) in <top (required)>'
WARNING: 'task :t, arg, :needs => [deps]' is deprecated.  Please use 'task :t, [args] => [deps]' instead.
    at /Users/jason_pearl/Developer/.rvm/gems/ruby-1.9.2-p180/gems/asset_hat-0.4.1/lib/asset_hat/tasks/js.rb:107:in`block (2 levels) in <top (required)>'
WARNING: 'task :t, arg, :needs => [deps]' is deprecated.  Please use 'task :t, [args] => [deps]' instead.
    at /Users/jason_pearl/Developer/.rvm/gems/ruby-1.9.2-p180/gems/asset_hat-0.4.1/lib/asset_hat/tasks.rb:7:in `block in <top (required)>'
