### PR TITLE
Fix dependencies so the tests can be run

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -21,12 +21,14 @@ begin
     gemspec.authors     = ['Ron DeVera', 'Mint Digital']
     gemspec.email       = 'hello@rondevera.com'
 
-    gemspec.add_development_dependency  'flexmock', '~> 0.8.6'
-    gemspec.add_development_dependency  'hanna',    '~> 0.1.12'
-    gemspec.add_development_dependency  'jeweler',  '~> 1.6.0'
-    gemspec.add_development_dependency  'shoulda',  '~> 2.10.2'
-    gemspec.add_runtime_dependency      'cssmin',   '~> 1.0.2'
-    gemspec.add_runtime_dependency      'jsmin',    '~> 1.0.1'
+    gemspec.add_development_dependency  'flexmock',   '~> 0.8.6'
+    gemspec.add_development_dependency  'hanna',      '~> 0.1.12'
+    gemspec.add_development_dependency  'jeweler',    '~> 1.6.0'
+    gemspec.add_development_dependency  'shoulda',    '~> 2.10.2'
+    gemspec.add_development_dependency  'actionpack', '~> 3.0.0'
+    gemspec.add_development_dependency  'test-unit',  '~> 2.0.0'
+    gemspec.add_runtime_dependency      'cssmin',     '~> 1.0.2'
+    gemspec.add_runtime_dependency      'jsmin',      '~> 1.0.1'
   end
   Jeweler::GemcutterTasks.new
 rescue LoadError

--- a/asset_hat.gemspec
+++ b/asset_hat.gemspec
@@ -115,7 +115,7 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<test-unit>, ["~> 2.0.0"])
       s.add_runtime_dependency(%q<cssmin>, ["~> 1.0.2"])
       s.add_runtime_dependency(%q<jsmin>, ["~> 1.0.1"])
-   else
+    else
       s.add_dependency(%q<flexmock>, ["~> 0.8.6"])
       s.add_dependency(%q<hanna>, ["~> 0.1.12"])
       s.add_dependency(%q<jeweler>, ["~> 1.6.0"])

--- a/asset_hat.gemspec
+++ b/asset_hat.gemspec
@@ -111,13 +111,17 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<hanna>, ["~> 0.1.12"])
       s.add_development_dependency(%q<jeweler>, ["~> 1.6.0"])
       s.add_development_dependency(%q<shoulda>, ["~> 2.10.2"])
+      s.add_development_dependency(%q<actionpack>, ["~> 3.0.0"])
+      s.add_development_dependency(%q<test-unit>, ["~> 2.0.0"])
       s.add_runtime_dependency(%q<cssmin>, ["~> 1.0.2"])
       s.add_runtime_dependency(%q<jsmin>, ["~> 1.0.1"])
-    else
+   else
       s.add_dependency(%q<flexmock>, ["~> 0.8.6"])
       s.add_dependency(%q<hanna>, ["~> 0.1.12"])
       s.add_dependency(%q<jeweler>, ["~> 1.6.0"])
       s.add_dependency(%q<shoulda>, ["~> 2.10.2"])
+      s.add_dependency(%q<actionpack>, ["~> 3.0.0"])
+      s.add_dependency(%q<test-unit>, ["~> 2.0.0"])
       s.add_dependency(%q<cssmin>, ["~> 1.0.2"])
       s.add_dependency(%q<jsmin>, ["~> 1.0.1"])
     end
@@ -126,6 +130,8 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<hanna>, ["~> 0.1.12"])
     s.add_dependency(%q<jeweler>, ["~> 1.6.0"])
     s.add_dependency(%q<shoulda>, ["~> 2.10.2"])
+    s.add_dependency(%q<actionpack>, ["~> 3.0.0"])
+    s.add_dependency(%q<test-unit>, ["~> 2.0.0"])
     s.add_dependency(%q<cssmin>, ["~> 1.0.2"])
     s.add_dependency(%q<jsmin>, ["~> 1.0.1"])
   end


### PR DESCRIPTION
Trying to run the tests using `bundle exec rake test` currently fails. This request adds `actionpack ~> 3.0.0` and `test-unit ~> 2.0.0` to the dependencies so that the tests will run,
