### PR TITLE
Allow file extensions in assets.yml

### DIFF
--- a/lib/asset_hat.rb
+++ b/lib/asset_hat.rb
@@ -233,8 +233,12 @@ module AssetHat
 
     dir = self.assets_dir(type)
     filenames = self.bundle_filenames(bundle, type)
-    filepaths = filenames.present? ?
-      filenames.map { |fn| File.join(dir, "#{fn}.#{type}") } : nil
+    return nil unless filenames.present?
+    
+    filenames.map do |fn|
+      paths = ["", ".#{type}"].map { |ext| File.join(dir, "#{fn}#{ext}") }
+      paths.find { |path| File.file?(path) }
+    end
   end
 
   # Reads <code>ActionController::Base.asset_host</code>, which can be a


### PR DESCRIPTION
Currently, using file extensions in files listed in `assets.yml` makes AssetHat unable to determine commit IDs for bundles. This patch makes `bundle_filepaths` more tolerant if the paths passed in already have the right extensions.
